### PR TITLE
adding +1 to malloc fixed memory issues according to valgrind

### DIFF
--- a/generic.c
+++ b/generic.c
@@ -2250,7 +2250,7 @@ struct fragd *fragmentStats(struct hash *hash, unsigned long long int *cnt2, uns
 
 char *print_bar(int x){
     char *s;
-    s = malloc(x);
+    s = malloc(x+1);
     int i;
     for (i = 0; i < x; i++){
         s[i] = '*';


### PR DESCRIPTION
according to valgrind, adding +1 to such malloc fixes the segmentation faults.

I presume this is due to the possibility of inputting empty bam/bed combinations to methylqa.
